### PR TITLE
Added indir parameter to import functions

### DIFF
--- a/R/cqimport.R
+++ b/R/cqimport.R
@@ -6,6 +6,7 @@
 #' The Cq is set to 40 in those wells were the threshold was not reached.
 #' 
 #' @param tablename: This is the filename of the .txt file containing Cq values as copied from the file manager. 
+#' @param indir: The path of the root directory containing the script.
 #' @param dropunnecessary: Defaults to TURE. If TRUE, returns only the columns "Well", "Target", "Sample", "Cq".
 #' @keywords qPCR, import
 #' @export cqimport
@@ -16,13 +17,13 @@
 #' filename <- "example_file_name"
 #' df <- cqimport(filename)
 
-cqimport <- function(tablename, dropunnecessary = TRUE){
+cqimport <- function(indir, tablename, dropunnecessary = TRUE){
   
   #First compile the .txt file name, assuming subfolder /input as source.
   #Then import the table with headings, assuming decimal separator ",".
  
   if(grepl("exampleData", tablename) == FALSE){
-    filename <- paste("input/", tablename, ".txt", sep = "")
+    filename <- paste(indir, "/input/", tablename, ".txt", sep = "")
   }
   
   df <- read.table(

--- a/R/mcimport.R
+++ b/R/mcimport.R
@@ -5,6 +5,7 @@
 #' First simply use the file name (without .txt) as input, assuming subfolder /input as source.
 #' 
 #' @param cqimport: A cqimport object. 
+#' @param indir: The path of the root directory containing the script.
 #' @param meltderivative: This is the file containing the meltcurve derivative data.
 #' @keywords qPCR, import
 #' @export mcimport
@@ -17,7 +18,7 @@
 #' df <- cqimport(filename)
 #' mc <- mcimport(cqimport = df, meltderivative = meltderivative)
 
-mcimport <- function(cqimport = df, meltderivative = meltderivative){
+mcimport <- function(indir, cqimport = df, meltderivative = meltderivative){
  
   #First load the required packages
   
@@ -27,7 +28,7 @@ mcimport <- function(cqimport = df, meltderivative = meltderivative){
   # Meltcurve analysis
   ## Import data
   
-  filename <- paste("input/", meltderivative, ".txt", sep = "")
+  filename <- paste(indir, "/input/", meltderivative, ".txt", sep = "")
   
   mc <- read.table(
     filename, 

--- a/man/cqimport.Rd
+++ b/man/cqimport.Rd
@@ -4,10 +4,12 @@
 \alias{cqimport}
 \title{Import BioRad qPCR Data}
 \usage{
-cqimport(tablename, dropunnecessary = TRUE)
+cqimport(indir, tablename, dropunnecessary = TRUE)
 }
 \arguments{
 \item{tablename:}{This is the filename of the .txt file containing Cq values as copied from the file manager.}
+
+\item{indir:}{The path of the root directory containing the script.}
 
 \item{dropunnecessary:}{Defaults to TURE. If TRUE, returns only the columns "Well", "Target", "Sample", "Cq".}
 }

--- a/man/mcimport.Rd
+++ b/man/mcimport.Rd
@@ -4,10 +4,12 @@
 \alias{mcimport}
 \title{Import BioRad qPCR Data}
 \usage{
-mcimport(cqimport = df, meltderivative = meltderivative)
+mcimport(indir, cqimport = df, meltderivative = meltderivative)
 }
 \arguments{
 \item{cqimport:}{A cqimport object.}
+
+\item{indir:}{The path of the root directory containing the script.}
 
 \item{meltderivative:}{This is the file containing the meltcurve derivative data.}
 }


### PR DESCRIPTION
The indir parameter now allows to specify the root directory of the /input and /output folders. This allows more flexibility for running the markdown script from a different location (and avoids knitting to .pdf errors on network drives).